### PR TITLE
Fix typo in ReadME

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -34,7 +34,7 @@ conn = sqlite3.connect("example.db")
 
 # Load the sqlite-vector extension
 # pip will install the correct binary package for your platform and architecture
-ext_path = importlib.resources.files("sqlite_vector.binaries") / "vector"
+ext_path = importlib.resources.files("sqlite-vector.binaries") / "vector"
 
 conn.enable_load_extension(True)
 conn.load_extension(str(ext_path))


### PR DESCRIPTION
Python package is installed in `sqlite-vector`, typo was introduced [here](https://github.com/sqliteai/sqlite-vector/commit/4790f8d0203b7df016057add73a6e356a66fb64d#diff-584b7d8640e9ea05ef9b8c20887f19a3ca2a74370996bb3e75b7576740fcc576)