### PR TITLE
chore: add Nix Flake support for reproducible builds and development

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "SQLite Vector Extension";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        stdenv = pkgs.stdenv;
+        version = "0.9.53";
+      in
+      {
+        packages.default = stdenv.mkDerivation {
+          pname = "sqlite-vector";
+          inherit version;
+
+          src = pkgs.lib.cleanSource ./.;
+
+          makeFlags = [
+            "CC=${stdenv.cc.targetPrefix}cc"
+          ] ++ pkgs.lib.optionals stdenv.isDarwin [
+            "ARCH=${if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}"
+          ];
+
+          installPhase = "install -D dist/vector* -t $out/lib";
+
+          checkInputs = [ pkgs.sqlite ];
+          doCheck = true;
+          checkPhase = ''
+            make test
+          '';
+        };
+
+        devShells.default =
+          let
+            sqlite-vector = self.packages.${system}.default;
+          in
+          pkgs.mkShell {
+            packages = [
+              pkgs.sqlite
+              pkgs.gnumake
+              sqlite-vector
+            ];
+
+            shellHook = ''
+              export SQLITE_VECTOR_LIB="${sqlite-vector}/lib/vector${stdenv.hostPlatform.extensions.sharedLibrary}"
+              echo "SQLite Vector extension available at: $SQLITE_VECTOR_LIB"
+              echo "Load it in sqlite3 with: .load $SQLITE_VECTOR_LIB"
+            '';
+          };
+      }
+    );
+}


### PR DESCRIPTION
Hi SQLite AI team,

First off, thank you for open-sourcing `sqlite-vector`. It is a fantastic extension, and the focus on "zero preindexing" and low memory footprint makes it incredibly useful for edge applications.

I’ve put together a PR that adds **Nix Flake** support to the repository.

### Why this is useful
Nix provides a purely functional deployment model that ensures reproducible builds across different environments. By adding a `flake.nix`, we allow developers and users to:

1.  **Onboard instantly:** Run `nix develop` to drop into a shell with all dependencies (`sqlite`, `make`, compilers) pre-configured. No need to manually install system libraries or worry about version mismatches.
2.  **Build and Install effortlessly:** Users can build and install the extension directly using the Nix package manager (e.g., `nix build github:sqliteai/sqlite-vector`), or easily include it as a dependency in their own Nix-based projects.
3.  **Build reproducibly:** Run `nix build` to compile the extension in a sandboxed environment, ensuring it works strictly with the declared dependencies.
4.  **Test easily:** The development shell automatically exports a `SQLITE_VECTOR_LIB` environment variable pointing to the built extension, making it trivial to test:
    ```bash
    # In the nix develop shell
    sqlite3 :memory: ".load $SQLITE_VECTOR_LIB" "SELECT vector_version();"
    ```

### What changed
This PR adds two files: `flake.nix` and `flake.lock`.
*   It utilizes the existing `Makefile` workflow, so it does not interfere with your current build process.
*   It handles platform-specific quirks automatically (e.g., correctly setting `CC` and handling macOS vs. Linux shared library extensions).

I hope you find this addition helpful for the community!