### PR TITLE
fix: replace static __m256i initializer with byte array to fix GCC 13 build

### DIFF
--- a/src/distance-avx2.c
+++ b/src/distance-avx2.c
@@ -959,10 +959,11 @@ float int8_distance_cosine_avx2 (const void *a, const void *b, int n) {
 
 // MARK: - BIT -
 
-// lookup table for popcount of 4-bit values
-static const __m256i popcount_lut = _mm256_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+// lookup table for popcount of 4-bit values (plain byte array — avoids GCC static-init restriction on intrinsics)
+static const char popcount_lut_bytes[32] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
 
 static inline __m256i popcount_avx2(__m256i v) {
+    __m256i popcount_lut = _mm256_loadu_si256((const __m256i*)popcount_lut_bytes);
     __m256i low_mask = _mm256_set1_epi8(0x0f);
     __m256i lo = _mm256_and_si256(v, low_mask);
     __m256i hi = _mm256_and_si256(_mm256_srli_epi16(v, 4), low_mask);


### PR DESCRIPTION
## Problem

Building `distance-avx2.c` with GCC 13 fails with:

```
src/distance-avx2.c:963:37: error: initializer element is not constant
  963 | static const __m256i popcount_lut = _mm256_setr_epi8(0, 1, 1, 2, ...);
      |                                     ^~~~~~~~~~~~~~~~
```

GCC 13 correctly rejects `_mm256_setr_epi8()` as a file-scope static
initializer because AVX2 intrinsics are not constant expressions in ISO C.
Earlier GCC versions and Clang accepted this as an extension.

## Fix

Replace the `static const __m256i popcount_lut` with a `static const char[32]`
byte array — a valid constant initializer — and load it with
`_mm256_loadu_si256` at the top of `popcount_avx2()`.

The change is semantically identical. When `popcount_avx2` is inlined (as
`static inline` intends), the compiler hoists the load out of the enclosing
loop, so there is no runtime cost.

## Testing

Verified on GCC 13.3.0, Ubuntu 24.04, x86-64. `make` completes cleanly and
the resulting `.so` passes `make test`.