### PR TITLE
Fix deprecated .iOS(.v11) platform declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "vector",
-    platforms: [.macOS(.v11), .iOS(.v11)],
+    platforms: [.macOS(.v11), .iOS(.v12)],
     products: [
         .library(
             name: "vector",


### PR DESCRIPTION
Xcode 17 deprecates the `v11` iOS platform symbol, so every consumer's package resolve emits:

> 'v11' is deprecated: iOS 12.0 is the oldest supported version

Bumping the declared floor to `.v12` silences the warning without loosening anything — the shipped xcframework already requires far newer runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)